### PR TITLE
Remove Microsoft.Extensions.Options reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,6 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.6" />

--- a/src/EurovisionHue/EurovisionHue.csproj
+++ b/src/EurovisionHue/EurovisionHue.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
-    <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Playwright" />
     <PackageReference Include="Polly.Extensions" />
     <PackageReference Include="SkiaSharp" />


### PR DESCRIPTION
The .NET 11 SDK identifies the dependency as redundant as it gets pruned (NU1510).
