### PR TITLE
Refactor secrets

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -15,13 +15,27 @@ permissions: {}
 
 jobs:
   bump-version:
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: '${{ github.workflow }}-bump'
       cancel-in-progress: false
 
+    environment:
+      name: write
+      deployment: false
+
+    permissions:
+      id-token: write
+
     steps:
+
+      - name: Get GitHub token
+        id: get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@d7d5bbb507c1f4b8fe3aff4f0199f9e24fff2ba5 # get-github-token/v4.1.1
+        with:
+          profile-name: write
 
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -29,7 +43,7 @@ jobs:
           filter: 'tree:0'
           persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          token: ${{ steps.get-github-token.outputs.token }}
 
       - name: Bump version
         id: bump-version
@@ -116,7 +130,7 @@ jobs:
           HEAD_BRANCH: ${{ steps.push-changes.outputs.branch-name }}
           NEXT_VERSION: ${{ steps.push-changes.outputs.version }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const nextVersion = process.env.NEXT_VERSION;
             const { repo, owner } = context.repo;
@@ -128,7 +142,7 @@ jobs:
               repo,
               head: process.env.HEAD_BRANCH,
               base: process.env.BASE_BRANCH,
-              draft: true,
+              draft: false,
               body: [
                 `Bump version to \`${nextVersion}\` for the next release.`,
                 '',
@@ -168,12 +182,15 @@ jobs:
             }
 
   close-milestone:
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: ubuntu-24.04
     if: github.event_name == 'release'
 
     concurrency:
       group: '${{ github.workflow }}-milestone'
       cancel-in-progress: false
+
+    permissions:
+      issues: write
 
     steps:
 
@@ -183,7 +200,7 @@ jobs:
           RELEASE_DATE: ${{ github.event.release.published_at }}
           RELEASE_VERSION: ${{ github.event.release.tag_name }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const { repo, owner } = context.repo;
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,20 @@ permissions: {}
 
 jobs:
   release:
-    runs-on: [ ubuntu-24.04 ]
+    runs-on: ubuntu-24.04
+    if: github.event.repository.fork == false
 
     concurrency:
       group: ${{ github.workflow }}
       cancel-in-progress: false
+
+    environment:
+      name: release
+      deployment: false
+
+    permissions:
+      contents: read
+      id-token: write
 
     steps:
 
@@ -25,9 +34,8 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           filter: 'tree:0'
-          persist-credentials: true # zizmor: ignore[artipacked] Needed to push commits
+          persist-credentials: false
           show-progress: false
-          token: ${{ secrets.COSTELLOBOT_TOKEN }}
 
       - name: Get version
         id: get-version
@@ -38,6 +46,12 @@ jobs:
           $version = $xml.SelectSingleNode('Project/PropertyGroup/VersionPrefix').InnerText
           "version=${version}" >> ${env:GITHUB_OUTPUT}
 
+      - name: Get GitHub token
+        id: get-github-token
+        uses: martincostello/github-automation/actions/get-github-token@d7d5bbb507c1f4b8fe3aff4f0199f9e24fff2ba5 # get-github-token/v4.1.1
+        with:
+          profile-name: release
+
       - name: Create release
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -45,7 +59,7 @@ jobs:
           DRAFT: ${{ inputs.publish != true }}
           VERSION: ${{ steps.get-version.outputs.version }}
         with:
-          github-token: ${{ secrets.COSTELLOBOT_TOKEN }}
+          github-token: ${{ steps.get-github-token.outputs.token }}
           script: |
             const { repo, owner } = context.repo;
             const draft = process.env.DRAFT === 'true';

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,7 +5,5 @@ rules:
     disable: true
   dependabot-cooldown:
     disable: true
-  secrets-outside-env:
-    disable: true
   undocumented-permissions:
     disable: true

--- a/build.ps1
+++ b/build.ps1
@@ -63,10 +63,10 @@ else {
     ${env:DOTNET_INSTALL_DIR} = Split-Path -Path (Get-Command dotnet).Path
 }
 
-$dotnet = Join-Path $env:DOTNET_INSTALL_DIR "dotnet"
+$dotnet = Join-Path ${env:DOTNET_INSTALL_DIR} "dotnet"
 
 if ($installDotNetSdk -eq $true) {
-    $env:PATH = "${env:DOTNET_INSTALL_DIR};${env:PATH}"
+    ${env:PATH} = "${env:DOTNET_INSTALL_DIR};${env:PATH}"
 }
 
 function DotNetPublish {
@@ -84,7 +84,7 @@ function DotNetTest {
 
     $additionalArgs = @()
 
-    if (-Not [string]::IsNullOrEmpty($env:GITHUB_SHA)) {
+    if (-Not [string]::IsNullOrEmpty(${env:GITHUB_SHA})) {
         $additionalArgs += "--logger:GitHubActions;report-warnings=false"
         $additionalArgs += "--logger:junit;LogFilePath=junit.xml"
     }


### PR DESCRIPTION
- Use GitHub token broker instead of `COSTELLOBOT_TOKEN`.
- Remove redundant credentials usage.
- Use consistent PowerShell env var syntax.
- Enable `secrets-outside-env` for zizmor.
