### PR TITLE
Sleep before verifying attestations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -208,6 +208,7 @@ jobs:
           subject-digest: ${{ steps.push.outputs.digest }}
 
       - name: Verify attestations
+        shell: bash
         env:
           CONTAINER_IMAGE_DIGEST: ${{ format('oci://{0}/{1}@{2}', env.REGISTRY, env.IMAGE_NAME, steps.push.outputs.digest) }}
           CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name == github.event.repository.default_branch && 'edge' || 'latest') }}
@@ -234,6 +235,7 @@ jobs:
           cosign-release: ${{ env.COSIGN_VERSION }}
 
       - name: Sign container images
+        shell: bash
         env:
           DIGEST: ${{ steps.push.outputs.digest }}
           TAGS: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,7 @@ jobs:
           CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name == github.event.repository.default_branch && 'edge' || 'latest') }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          sleep 15s
           gh attestation verify --repo "${GITHUB_REPOSITORY}" "${CONTAINER_IMAGE_DIGEST}" || exit 1
           gh attestation verify --repo "${GITHUB_REPOSITORY}" "${CONTAINER_IMAGE_LABEL}" || exit 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,9 +213,17 @@ jobs:
           CONTAINER_IMAGE_LABEL: ${{ format('oci://{0}/{1}:{2}', env.REGISTRY, env.IMAGE_NAME, github.ref_name == github.event.repository.default_branch && 'edge' || 'latest') }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          sleep 15s
-          gh attestation verify --repo "${GITHUB_REPOSITORY}" "${CONTAINER_IMAGE_DIGEST}" || exit 1
-          gh attestation verify --repo "${GITHUB_REPOSITORY}" "${CONTAINER_IMAGE_LABEL}" || exit 1
+          for image in "${CONTAINER_IMAGE_DIGEST}" "${CONTAINER_IMAGE_LABEL}"; do
+             attempts=0
+             until gh attestation verify --repo "${GITHUB_REPOSITORY}" "${image}"; do
+               attempts=$((attempts + 1))
+               if [ "${attempts}" -ge 6 ]; then
+                 echo "Attestation verification failed for ${image} after ${attempts} attempts."
+                 exit 1
+               fi
+               sleep 5s
+             done
+           done
 
       - name: Install cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2


### PR DESCRIPTION
Wait 15 seconds before verifying attestations to avoid [404](https://github.com/martincostello/eurovision-hue/actions/runs/28225409582/job/83616476795#step:9:58) due to propagation not being complete.

> Error: HTTP 404: Not Found (https://api.github.com/repos/martincostello/eurovision-hue/attestations/sha256:946cb031db04dd63a9843c08296bc4ed5ecb728882db693b735f79a2ba85fd15?per_page=30&predicate_type=https%3A%2F%2Fslsa.dev%2Fprovenance%2Fv1)