### PR TITLE
Restore property fuzz tests

### DIFF
--- a/tests/EurovisionHue.Tests/ParticipantsTests.cs
+++ b/tests/EurovisionHue.Tests/ParticipantsTests.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2025. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-using FsCheck;
 using FsCheck.Fluent;
 
 namespace MartinCostello.EurovisionHue;
@@ -117,27 +116,24 @@ public static class ParticipantsTests
         participant.ShouldBeNull();
     }
 
-    [Fact]
-    public static void Participant_Colors_Meets_Specification() =>
-        Check.One(
-            Config.QuickThrowOnFailure.WithMaxTest(500),
-            Prop.ForAll(
-                Gen.Elements(ParticipantTestCases().AsEnumerable()).Select((p) => p.Data.Item1).ToArbitrary(),
-                Gen.Choose(1, 100).ToArbitrary(),
-                (name, count) =>
-                {
-                    // Act
-                    var actual = Participants.TryFind(name, out var participant);
+    [FsCheck.Xunit.Property(MaxTest = 500)]
+    public static void Participant_Colors_Meets_Specification() => Prop.ForAll(
+        Gen.Elements(ParticipantTestCases().AsEnumerable()).Select((p) => p.Data.Item1).ToArbitrary(),
+        Gen.Choose(1, 100).ToArbitrary(),
+        (name, count) =>
+        {
+            // Act
+            var actual = Participants.TryFind(name, out var participant);
 
-                    // Assert
-                    actual.ShouldBeTrue();
-                    participant.ShouldNotBeNull();
+            // Assert
+            actual.ShouldBeTrue();
+            participant.ShouldNotBeNull();
 
-                    // Act
-                    var colors = participant.Colors(count);
+            // Act
+            var colors = participant.Colors(count);
 
-                    // Assert
-                    colors.ShouldNotBeNull();
-                    colors.ShouldNotBeEmpty();
-                }));
+            // Assert
+            colors.ShouldNotBeNull();
+            colors.ShouldNotBeEmpty();
+        });
 }


### PR DESCRIPTION
Revert changes from #505 that were necessary before FsCheck supported xunit v3 4.0.0.
